### PR TITLE
feat: define TypeScript interfaces for API response

### DIFF
--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -1,0 +1,28 @@
+export interface Cuisine {
+  name: string
+  uniqueName: string
+}
+
+export interface Address {
+  city: string
+  firstLine: string
+  postalCode: string
+}
+
+export interface Rating {
+  count: number
+  starRating: number
+  userRating: number | null
+}
+
+export interface Restaurant {
+  id: string
+  name: string
+  cuisines: Cuisine[]
+  rating: Rating
+  address: Address
+}
+
+export interface ApiResponse {
+  restaurants: Restaurant[]
+}


### PR DESCRIPTION
The interfaces map to the live API response:

- Restaurants.name

- Rating.starRating —> the number we will display

- Rating.userRating —> typed as number  (or null since the API can return null)

- Address —> firstLine, city, postalCode 

      for example:
      address.firstLine   // "63 St Paul's Churchyard"
      address.city        // "London"
      address.postalCode  // "EC4M 8AB"

- ApiResponse —> because of the fact that the API response contains first the metadata {...} and then the restaurants {..}, to get the restaurants' info we will need to call it like this for example: 
     const response: ApiResponse = await fetch(url)
     response.restaurants[0].name
 
   So now we need to tell TypeScript that what comes back from the API is an object with a restaurants array inside it. This is how TypeScript will know that the array of restaurants is at response.restaurants

