### PR TITLE
5 api service

### DIFF
--- a/src/services/restaurantService.ts
+++ b/src/services/restaurantService.ts
@@ -4,17 +4,18 @@ const BASE_URL =
   'https://uk.api.just-eat.io/discovery/uk/restaurants/enriched/bypostcode'
 
 export async function getRestaurantsByPostcode(postcode: string): Promise<Restaurant[]> {
-  const sanitised = postcode.trim().replace(/\s+/g, '') //sanitise postcode before building request URL
+  // Assumption 1: the API accepts postcodes without spaces 
+  const sanitised = postcode.trim().replace(/\s+/g, '')
 
   let response: Response
   try {
     response = await fetch(`${BASE_URL}/${sanitised}`)
-  } catch {// error handling for network issues
+  } catch {
     throw new Error('Network error: unable to reach the Just Eat API.')
   }
 
   if (!response.ok) {
-    throw new Error(//check body missing response
+    throw new Error(
       `API error: ${response.status} ${response.statusText}. Check the postcode and try again.`,
     )
   }


### PR DESCRIPTION
Created src/services/restaurantService.ts which handles fetching restaurant data from the Just Eat API.
The function getRestaurantsByPostcode() takes a postcode as input, calls the API and returns the first 10 restaurants.

What I implemented:

- Postcode sanitisation before building the URL (to remove the possible  white spaces in the postcode)
- Error handling for three cases: network failure, bad API response and missing restaurants array in the response
- Slices the result to the first 10 restaurants as required


!!!ASSUMPTION (in the future): The assignment just says "rating as a number",  it does not specify which of these three fields to use. So I will choose to display  starRating (mostly because it is always a number, it is the most meaningful one, and also userRating is frequently null in the real API response)