### PR TITLE
7-search-bar

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -24,6 +24,7 @@ function handleSubmit() {
 
 <template>
   <form @submit.prevent="handleSubmit">
+    <!-- Reset error on every keystroke so it doesn't linger after the user corrects the postcode -->
     <input
       v-model="postcode"
       type="text"


### PR DESCRIPTION
Validates against the standard UK postcode before emitting
Shows an inline error if invalid, does not emit
Clears the error as soon as the user types again
No styling yet, I will do that using Figma Make