### PR TITLE
9 restaurant card

### DIFF
--- a/src/components/RestaurantCard.vue
+++ b/src/components/RestaurantCard.vue
@@ -1,16 +1,33 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Restaurant } from '../types/restaurant'
 
-const props = defineProps<{//what data is expected to receive
+// Defines what data this component expects to receive from its parent
+const props = defineProps<{
   restaurant: Restaurant
 }>()
+
+// Joins cuisine names into a readable comma-separated string e.g. "Indian, Pizza"
+const cuisineNames = computed(() =>
+  props.restaurant.cuisines.map((c) => c.name).join(', ') || 'Not available',
+)
+
+// Compose the full address
+const fullAddress = computed(() => {
+  const { firstLine, city, postalCode } = props.restaurant.address
+  return [firstLine, city, postalCode].filter(Boolean).join(', ')
+})
+
+// Assumption: starRating is the best rating number from the API. (userRating is frequently null in live responses so we do not use it
+const rating = computed(() => props.restaurant.rating.starRating ?? 'N/A')
 </script>
 
 <template>
   <div>
-    <h2>{{ props.restaurant.name }}</h2>//the restaurant name is displayed as a heading
-    <p>{{ props.restaurant.cuisines }}</p>
-    <p>{{ props.restaurant.rating.starRating }}</p>
-    <p>{{ props.restaurant.address }}</p>
+    <!-- restaurant name displayed as a heading -->
+    <h2>{{ props.restaurant.name }}</h2>
+    <p>{{ cuisineNames }}</p>
+    <p>{{ rating }}</p>
+    <p>{{ fullAddress }}</p>
   </div>
 </template>


### PR DESCRIPTION
Assumption: which rating field to display: the API returns two rating fields: starRating (always a number) and userRating (frequently null in live responses). I chose to display starRating. If starRating is also absent, the card shows N/A.

- Cuisines names are joined, separated by commas
- Address fields (firstLine, city, postalCode) are composed into a single line e.g. "123 High Street, London, EC4M 7RF". Missing fields are filtered out so you never get empty commas
- I used  computed() for cuisines and address (I did that just because it is a good practice: any value that is derived from a prop or reactive data should be computed)